### PR TITLE
feat: add updated_at to all models

### DIFF
--- a/api/api_v1.py
+++ b/api/api_v1.py
@@ -142,7 +142,7 @@ def get_clusters(request, filters: Query[ClusterFilter], limit=250, offset=0):
     """
     clusters = paginate(filters.filter(Cluster.objects.with_related()), limit, offset)
 
-    out = [
+    out = (
         ClusterResponse(
             name=cluster.name,
             description=cluster.description,
@@ -157,6 +157,8 @@ def get_clusters(request, filters: Query[ClusterFilter], limit=250, offset=0):
                 d.field.name: d.value
                 for d in cluster.data.all()
             } if cluster.data.exists() else None,
+            created_at=cluster.created_at,
+            updated_at=cluster.updated_at,
         ) for cluster in clusters
-    ]
+    )
     return {'clusters': out, 'count': clusters.count()}

--- a/api/schema/filters.py
+++ b/api/schema/filters.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Annotated, Any
 
 import pydantic
@@ -25,9 +26,17 @@ class ClusterFilter(FilterSchema):
     # how tag queries are to be performed, either with a logical AND or OR
     # this field is popped out of the generated filter in overridden `get_filter_expression`
     tags_logical_operator: Annotated[
-        LogicalExpression | None,
+        LogicalExpression,
         Field(q=None, description="The logical operation to use when querying for tags")
     ] = LogicalExpression.AND
+
+    updated_at: Annotated[
+        datetime | None,
+        Field(alias='updated_since',
+              q='updated_at__gte',
+              description='Find clusters that were updated after this datetime in ISO 8601 or '
+                          'Unix timestamps; ex: 2025-04-02T12:40:01-05:00')
+    ] = None
 
     def get_filter_expression(self) -> Q:
         """ Overrides parent method to remove the "tags_logical_operator" from the resulting

--- a/api/schema/out.py
+++ b/api/schema/out.py
@@ -1,4 +1,5 @@
 import enum
+from datetime import datetime
 from typing import Any
 
 from ninja import Schema
@@ -25,7 +26,8 @@ class FleetLabelResponse(Schema):
     value: str
 
 
-ClusterIntentResponse = create_schema(ClusterIntent, exclude=['id', 'cluster'])
+ClusterIntentResponse = create_schema(
+    ClusterIntent, exclude=('id', 'cluster', 'created_at', 'updated_at'))
 
 
 class LogicalExpression(enum.StrEnum):
@@ -41,6 +43,8 @@ class ClusterResponse(Schema):
     fleet_labels: list[FleetLabelResponse]
     data: dict[str, str | None] | None
     intent: ClusterIntentResponse | None
+    created_at: datetime | None
+    updated_at: datetime | None
 
 
 class ClustersResponse(Schema):

--- a/parameter_store/admin_default.py
+++ b/parameter_store/admin_default.py
@@ -24,6 +24,10 @@ from unfold.forms import AdminPasswordChangeForm, UserChangeForm, UserCreationFo
 
 
 class CustomAdminSite(unfold.sites.UnfoldAdminSite):
+    site_header = 'Parameter Store Admin'
+    site_title = 'Parameter Store Admin'
+    index_title = 'Parameter Store Admin'
+
     def has_permission(self, request):
         return request.user.is_superuser
 

--- a/parameter_store/apps.py
+++ b/parameter_store/apps.py
@@ -1,0 +1,10 @@
+from django.apps import AppConfig
+
+
+class ParamStoreAppConfig(AppConfig):
+    name = 'parameter_store'
+    verbose_name = 'Parameter Store'
+
+    def ready(self):
+        # import signals to register them in the app
+        from . import signals  # noqa

--- a/parameter_store/models.py
+++ b/parameter_store/models.py
@@ -101,6 +101,8 @@ class DynamicValidatingModel(models.Model):
 class Group(DynamicValidatingModel):
     name = models.CharField(db_index=True, max_length=30, blank=False, unique=True, null=False)
     description = models.CharField(max_length=255, null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
 
     def __str__(self):
         return self.name
@@ -134,6 +136,8 @@ class Cluster(DynamicValidatingModel):
         through='ClusterTag',
         related_name='clusters',
     )
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
 
     objects = ClusterManager()
 
@@ -157,6 +161,8 @@ class Tag(DynamicValidatingModel):
     name = models.CharField(max_length=30, blank=False, unique=True, null=False,
                             verbose_name='tag name')
     description = models.CharField(max_length=255, null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
 
     def __str__(self):
         return self.name
@@ -169,6 +175,8 @@ class ClusterTag(DynamicValidatingModel):
 
     cluster = models.ForeignKey(Cluster, on_delete=models.DO_NOTHING)
     tag = models.ForeignKey(Tag, on_delete=models.CASCADE)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
 
     def __str__(self):
         return f'{self.cluster.name} - {self.tag.name}'
@@ -286,6 +294,8 @@ class ClusterIntent(DynamicValidatingModel):
         help_text='Comma-separated list of VLAN IDs for subnets'
     )
     recreate_on_delete = models.BooleanField(default=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
 
     def __str__(self):
         return self.cluster.name
@@ -302,6 +312,8 @@ class ClusterFleetLabel(DynamicValidatingModel):
     cluster = models.ForeignKey(Cluster, on_delete=models.CASCADE, related_name="fleet_labels")
     key = models.CharField(max_length=63, blank=False, null=False)
     value = models.CharField(max_length=63, blank=False, null=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
 
     def __str__(self):
         return f'{self.cluster.name} - "{self.key}" = "{self.value}"'
@@ -364,8 +376,9 @@ class Validator(models.Model):
         null=False,
         help_text="Enter parameters for the validator in JSON format. Due to limitations in the "
                   "UI, arguments for validators cannot be displayed dynamically. Contents of "
-                  "this field will be validated and feedback will be provided."
-    )
+                  "this field will be validated and feedback will be provided.")
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
 
     def __str__(self):
         return self.name
@@ -406,8 +419,9 @@ class ValidatorAssignment(models.Model):
         blank=False,
         null=False,
         choices=get_model_field_choices(),
-        help_text="Select model and its field"
-    )
+        help_text="Select model and its field")
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
 
     class Meta:
         verbose_name = "Standard Validator Assignment"
@@ -435,6 +449,8 @@ class ClusterDataField(models.Model):
 
     name = models.CharField(max_length=64, blank=False, unique=True, null=False)
     description = models.CharField(max_length=255, null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
 
     def __str__(self):
         return self.name
@@ -450,6 +466,8 @@ class ClusterDataFieldValidatorAssignment(models.Model):
 
     field = models.ForeignKey(ClusterDataField, on_delete=models.DO_NOTHING)
     validator = models.ForeignKey(Validator, on_delete=models.DO_NOTHING)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
 
     def __str__(self):
         return f'Field "{self.field.name}" - Validator "{self.validator.name}"'
@@ -466,6 +484,8 @@ class ClusterData(models.Model):
     cluster = models.ForeignKey(Cluster, on_delete=models.CASCADE, related_name="data")
     field = models.ForeignKey(ClusterDataField, on_delete=models.CASCADE)
     value = models.CharField(max_length=1024, null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
 
     def __str__(self):
         return f'{self.cluster.name} - "{self.field.name}" = "{self.value}"'

--- a/parameter_store/settings.py
+++ b/parameter_store/settings.py
@@ -26,22 +26,14 @@ https://docs.djangoproject.com/en/5.1/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.1/ref/settings/
 """
+import colorsys
 import os
-
-# rgb to hex conversion
-import colorsys 
 from pathlib import Path
 
 from django.templatetags.static import static
 
-from parameter_store.util import str_to_bool
-
-# libraries for unfold navbar
-from django.urls import reverse_lazy  
-from django.utils.translation import gettext_lazy as _
-
-# customer settings such as logo image path and company hex color
 from parameter_store.customerconfig import img_path, primary_color_hex
+from parameter_store.util import str_to_bool
 
 version = "v1.0.0"
 
@@ -66,8 +58,6 @@ CSRF_TRUSTED_ORIGINS = [
 
 # Application definition
 INSTALLED_APPS = [
-    'parameter_store',
-    "api",
     'unfold',
     'unfold.contrib.inlines',
     'unfold.contrib.filters',
@@ -79,6 +69,8 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'parameter_store',
+    "api",
 ]
 
 if DEBUG:
@@ -165,11 +157,10 @@ AUTHENTICATION_BACKENDS = [
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
-
 USE_I18N = True
 
 USE_TZ = True
+TIME_ZONE = os.environ.get('TIME_ZONE', 'UTC')
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.1/howto/static-files/
@@ -217,19 +208,20 @@ CSRF_COOKIE_SECURE = True
 CORS_ALLOW_CREDENTIALS = True
 SESSION_COOKIE_AGE = os.environ.get('PARAM_STORE_COOKIE_TTL', 3600)  # one hour default
 
+
 # generate hls color palette based on company color hex
 def generate_hls_palette(hex_color):
     hex_color = hex_color.lstrip('#')
-    
+
     r = int(hex_color[0:2], 16) / 255.0
     g = int(hex_color[2:4], 16) / 255.0
     b = int(hex_color[4:6], 16) / 255.0
 
-    h, l, s = colorsys.rgb_to_hls(r,g,b)
+    h, l, s = colorsys.rgb_to_hls(r, g, b)
     palette = {}
 
     shades = [50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950]
-    
+
     for shade in shades:
         if shade <= 500:
             new_l = l + (500 - shade) / 500 * (1 - l)
@@ -239,10 +231,11 @@ def generate_hls_palette(hex_color):
         new_r, new_g, new_b = colorsys.hls_to_rgb(h, new_l, s)
         r, g, b = int(new_r * 255), int(new_g * 255), int(new_b * 255)
         new_hex = f'#{r:02x}{g:02x}{b:02x}'
-        
+
         palette[str(shade)] = new_hex
 
     return palette
+
 
 # Param Store App Settings
 UNFOLD = {
@@ -284,10 +277,9 @@ if img_path:
             "rel": "icon",
             "sizes": "32x32",
             "type": "image/svg+xml",
-            "href": lambda request: static(img_path) 
+            "href": lambda request: static(img_path)
         }
     ]
-
 
 # Defaults to enabled
 IAP_ENABLED = str_to_bool(os.environ.get('PARAM_STORE_IAP_ENABLED', True))

--- a/parameter_store/signals.py
+++ b/parameter_store/signals.py
@@ -1,0 +1,89 @@
+from django.core.cache import cache
+from django.db.models.signals import post_save, post_delete
+from django.dispatch import receiver
+
+from .models import ClusterDataField, Tag, ClusterTag, ClusterIntent, \
+    ClusterFleetLabel, ClusterData, Cluster
+
+
+def update_cluster_timestamp(cluster, updated_at):
+    """Updates the 'updated_at' timestamp on a given Cluster instance.
+
+    Args:
+        updated_at: datetime
+    """
+    if cluster:
+        Cluster.objects.filter(pk=cluster.pk).update(updated_at=updated_at)
+
+
+@receiver(post_save, sender=ClusterTag)
+@receiver(post_save, sender=ClusterIntent)
+@receiver(post_save, sender=ClusterFleetLabel)
+@receiver(post_save, sender=ClusterData)
+def related_object_saved(sender, instance, **kwargs):
+    """ Listens for save events on models with FK/O2O to Cluster.
+    Updates the Cluster's updated_at timestamp.
+    """
+    cluster = None
+    if hasattr(instance, 'cluster') and instance.cluster:
+        cluster = instance.cluster
+
+    if cluster:
+        update_cluster_timestamp(cluster, instance.updated_at)
+
+
+@receiver(post_save, sender=ClusterTag)
+@receiver(post_save, sender=ClusterIntent)
+@receiver(post_save, sender=ClusterFleetLabel)
+@receiver(post_save, sender=ClusterData)
+def related_object_deleted(sender, instance, **kwargs):
+    """  Listens for delete events on models with FK/O2O to Cluster.
+    Updates the Cluster's updated_at timestamp.
+    """
+    cluster = None
+    if hasattr(instance, 'cluster') and instance.cluster:
+        # Note: On deletion, the related object might already be partially gone,
+        # but the foreign key reference should still be accessible here.
+        cluster = instance.cluster
+
+    if cluster:
+        update_cluster_timestamp(cluster, instance.updated_at)
+
+
+# This is intentionally dark code; leaving this commented out.
+# We don't have m2m relationships currently because we're using through tables, but that doesn't
+# mean we won't ever have them.  This should work with few changes if needed.
+# # We listen to the M2M field on the Cluster model directly
+# @receiver(m2m_changed, sender=Cluster.tags.through)  # '.through' gets the intermediate model
+# def tags_changed_on_cluster(sender, instance, action, pk_set, **kwargs):
+#     """  Listens for changes on the Cluster.tags ManyToMany relationship.
+#     Updates the Cluster's updated_at timestamp.
+#
+#     'instance' here is the Cluster instance.
+#     'action' can be 'pre_add', 'post_add', 'pre_remove', 'post_remove', 'pre_clear', 'post_clear'.
+#     'pk_set' is a set of primary keys of the related objects (Tags) being added/removed.
+#     """
+#     # We only care about actions that actually modify the relationship
+#     if action in ['post_add', 'post_remove', 'post_clear']:
+#         if isinstance(instance, Cluster):
+#             update_cluster_timestamp(instance, instance.updated_at)
+
+
+@receiver(post_save, sender=Tag)
+def invalidate_tag_cache_on_save(sender, **kwargs):
+    cache.delete('tag_choices_inline')
+
+
+@receiver(post_delete, sender=Tag)
+def invalidate_tag_cache_on_delete(sender, **kwargs):
+    cache.delete('tag_choices_inline')
+
+
+@receiver(post_save, sender=ClusterDataField)
+def invalidate_cluster_data_field_choices_on_save(sender, instance, **kwargs):
+    cache.delete('cluster_data_field_choices')
+
+
+@receiver(post_delete, sender=ClusterDataField)
+def invalidate_cluster_data_field_choices_on_delete(sender, instance, **kwargs):
+    cache.delete('cluster_data_field_choices')

--- a/parameter_store/urls.py
+++ b/parameter_store/urls.py
@@ -23,18 +23,19 @@ The `urlpatterns` list routes URLs to views. For more information please see:
 from django.shortcuts import redirect
 from django.urls import path, include
 from django.urls.conf import re_path
+from django.views.generic import RedirectView
 
 from . import settings
 from .admin import param_admin_site
-from .admin_user_and_group import admin_site
+from .admin_default import admin_site
 
 urlpatterns = [
-    path('', lambda request: redirect('/params/')),
+    path('', RedirectView.as_view(url='/params/', permanent=True)),
     path('admin/', admin_site.urls),
     path('params/', param_admin_site.urls),
     path('api/v1/', include('api.urls')),
     # redirect anything /api, /api/, /api/docs to /api/v1/docs
-    re_path(r'^api/?(?:docs)?$', lambda request: redirect('/api/v1/docs'))
+    re_path(r'^api/?(?:docs)?$', RedirectView.as_view(url='/api/v1/docs', permanent=True))
     # path('auto/', include('auto_api.urls')),
 
 ]


### PR DESCRIPTION
All objects get updated_at field.  Cluster and cluster-related objects get signals; an updated, related object will update the parent cluster updated_at field automatically.  Adds support for querying cluster objects that have been updated since a given timestamp.

refactor: reorganized imports in settings.py

refactor: updates redirect URLs in parameter_store urlpatterns to use `RedirectView`

refactor: `ParamStoreAppConfig` now properly configured and moved to apps.py

fix: CustomAdminSite gets proper site headers and titles in admin UI

feat: allow server time zone to be set by environment variable `TIME_ZONE`