### PR TITLE
feat: add secondary groups for clusters and group custom data

### DIFF
--- a/api/api_v1.py
+++ b/api/api_v1.py
@@ -17,16 +17,19 @@
 from django.contrib.admin.views.decorators import staff_member_required
 from django.db import connection, connections
 from django.db.migrations.executor import MigrationExecutor
+from django.db.models import Prefetch
+from django.http import HttpRequest
 from ninja import NinjaAPI, Query
+from ninja.errors import HttpError
 from ninja.pagination import LimitOffsetPagination
 from ninja.pagination import paginate as ninja_paginate
-from ninja.responses import codes_4xx, codes_5xx
 from ninja.security import django_auth
 
-from parameter_store.models import Cluster, Group, Tag
+from parameter_store.models import Cluster, Group, Tag, GroupData
 from .schema.filters import ClusterFilter
-from .schema.out import HealthResponse, MessageResponse, NameDescResponse, ClustersResponse, \
-    ClusterResponse, FleetLabelResponse, PingResponse
+from .schema.out import HealthResponse, NameDescResponse, ClustersResponse, \
+    ClusterResponse, FleetLabelResponse, PingResponse, GroupResponse, MessageResponse, \
+    GroupsResponse
 from .utils import require_permissions, paginate
 
 api_v1 = NinjaAPI(title="Parameter Store API",
@@ -34,12 +37,9 @@ api_v1 = NinjaAPI(title="Parameter Store API",
                   csrf=True,
                   docs_decorator=staff_member_required)
 
-std_resp = {codes_4xx: MessageResponse,
-            codes_5xx: MessageResponse}
-
 
 @api_v1.get('/ping', response=PingResponse, summary='Basic health check')
-def ping(request):
+def ping(request: HttpRequest):
     """ This health check is very basic, providing only a basic alive check of the API
     application and Django server.  No database checks are performed.  If you receive an HTTP 200
     status with a response body, the server is alive.
@@ -51,7 +51,7 @@ def ping(request):
     "/status",
     response=HealthResponse,
     summary="Deep health check with database status")
-def health(request):
+def health(request: HttpRequest):
     """  Health check endpoint that verifies database connectivity and migrations status.
     """
     health_status = {
@@ -106,37 +106,113 @@ def health(request):
     '/tags',
     response=list[NameDescResponse],
     auth=django_auth,
-    summary='Cluster tags')
+    summary='Get cluster tags')
 @ninja_paginate(LimitOffsetPagination)
 @require_permissions('can_get_params_api')
 def tags(request):
-    """ Clusters may have tags associated with them. Tags are simple string values.  This endpoint returns
-    all avaialbe tags which may be associated with a cluster.
+    """ Clusters may have tags associated with them. Tags are simple string values. This endpoint
+    returns all available tags which may be associated with a cluster.
     """
     return Tag.objects.all()
 
 
 @api_v1.get(
-    "/groups",
-    response=list[NameDescResponse],
+    '/group/{group}',
+    response={200: GroupResponse, 404: MessageResponse, 409: MessageResponse},
     auth=django_auth,
-    summary='Groups')
-@ninja_paginate(LimitOffsetPagination)
+    summary='Get a single group')
+def get_group(request: HttpRequest, group: str):
+    """   Gets a specific group by its name.
+    """
+    # Query the for the group, prefetch related data
+    groups = Group.objects.prefetch_related(
+        Prefetch('group_data', queryset=GroupData.objects.select_related('field')))
+
+    try:
+        g = groups.get(name=group)
+    except Group.DoesNotExist:
+        return 404, {"message": "group not found"}
+    except Group.MultipleObjectsReturned:
+        raise HttpError(500, "multiple groups found")
+
+    return GroupResponse(
+        name=g.name,
+        description=g.description,
+        data={d.field.name: d.value for d in
+              g.group_data.all()} if g.group_data.exists() else None,
+    )
+
+
+@api_v1.get(
+    "/groups",
+    response=GroupsResponse,
+    auth=django_auth,
+    summary='Get many groups')
 @require_permissions('can_get_params_api')
-def groups(request):
+def get_groups(request: HttpRequest, limit=250, offset=0):
     """ Clusters belong to groups. This endpoint returns all available groups to which a cluster
     may belong.
     """
-    return Group.objects.all()
+    # Query the for the groups while prefetching related data
+    data_prefetch = Prefetch('group_data', queryset=GroupData.objects.select_related('field'))
+    qs = Group.objects.prefetch_related(data_prefetch).all()
+    groups = paginate(qs, limit, offset)
+
+    out = (
+        GroupResponse(
+            name=group.name,
+            description=group.description,
+            data={d.field.name: d.value for d in
+                  group.group_data.all()} if group.group_data.exists() else None,
+        ) for group in groups
+    )
+    return {'groups': out, 'count': groups.count()}
+
+
+@api_v1.get(
+    '/cluster/{cluster}',
+    response={200: ClusterResponse, 404: MessageResponse, 500: MessageResponse},
+    auth=django_auth,
+    summary='Get a single cluster')
+@require_permissions('can_get_params_api')
+def get_cluster(request: HttpRequest, cluster: str):
+    """ This API endpoint provides view-only cluster objects and their associated metadata,
+    including cluster group, fleet label, custom data, cluster intent.
+    """
+    try:
+        c = Cluster.objects.with_related().get(name=cluster)
+    except Cluster.DoesNotExist:
+        return 404, {"message": "cluster not found"}
+    except Cluster.MultipleObjectsReturned:
+        raise HttpError(500, "multiple clusters found")
+
+    return ClusterResponse(
+        name=c.name,
+        description=c.description,
+        group=c.group.name,
+        secondary_groups=[g.name for g in c.secondary_groups.all()],
+        tags=[tag.name for tag in c.tags.all()],
+        fleet_labels=[
+            FleetLabelResponse(key=fl.key, value=fl.value)
+            for fl in c.fleet_labels.all()
+        ],
+        intent=c.intent if hasattr(c, 'intent') else None,
+        data={
+            d.field.name: d.value
+            for d in c.cluster_data.all()
+        } if c.cluster_data.exists() else None,
+        created_at=c.created_at,
+        updated_at=c.updated_at,
+    )
 
 
 @api_v1.get(
     '/clusters',
     response=ClustersResponse,
     auth=django_auth,
-    summary='Clusters and their associated data')
+    summary='Get many clusters')
 @require_permissions('can_get_params_api')
-def get_clusters(request, filters: Query[ClusterFilter], limit=250, offset=0):
+def get_clusters(request: HttpRequest, filters: Query[ClusterFilter], limit=250, offset=0):
     """ This API endpoint provides view-only cluster objects and their associated metadata,
     including cluster group, fleet label, custom data, cluster intent.
     """
@@ -156,8 +232,8 @@ def get_clusters(request, filters: Query[ClusterFilter], limit=250, offset=0):
             intent=cluster.intent if hasattr(cluster, 'intent') else None,
             data={
                 d.field.name: d.value
-                for d in cluster.data.all()
-            } if cluster.data.exists() else None,
+                for d in cluster.cluster_data.all()
+            } if cluster.cluster_data.exists() else None,
             created_at=cluster.created_at,
             updated_at=cluster.updated_at,
         ) for cluster in clusters

--- a/api/api_v1.py
+++ b/api/api_v1.py
@@ -140,6 +140,8 @@ def get_group(request: HttpRequest, group: str):
         description=g.description,
         data={d.field.name: d.value for d in
               g.group_data.all()} if g.group_data.exists() else None,
+        created_at=g.created_at,
+        updated_at=g.updated_at
     )
 
 
@@ -164,6 +166,8 @@ def get_groups(request: HttpRequest, limit=250, offset=0):
             description=group.description,
             data={d.field.name: d.value for d in
                   group.group_data.all()} if group.group_data.exists() else None,
+            created_at=group.created_at,
+            updated_at=group.updated_at
         ) for group in groups
     )
     return {'groups': out, 'count': groups.count()}

--- a/api/api_v1.py
+++ b/api/api_v1.py
@@ -147,6 +147,7 @@ def get_clusters(request, filters: Query[ClusterFilter], limit=250, offset=0):
             name=cluster.name,
             description=cluster.description,
             group=cluster.group.name,
+            secondary_groups=[g.name for g in cluster.secondary_groups.all()],
             tags=[tag.name for tag in cluster.tags.all()],
             fleet_labels=[
                 FleetLabelResponse(key=fl.key, value=fl.value)

--- a/api/schema/filters.py
+++ b/api/schema/filters.py
@@ -12,7 +12,8 @@ from api.schema.out import LogicalExpression
 class ClusterFilter(FilterSchema):
     group: Annotated[
         str | None,
-        Field(q='group__name', description="Cluster group to match; accepts only one")
+        Field(q=['group__name', 'secondary_groups__name'],
+              description="Cluster group to match; accepts only one")
     ] = None
 
     tags: Annotated[

--- a/api/schema/out.py
+++ b/api/schema/out.py
@@ -39,6 +39,7 @@ class ClusterResponse(Schema):
     name: str
     description: str | None
     group: str
+    secondary_groups: list[str]
     tags: list[str]
     fleet_labels: list[FleetLabelResponse]
     data: dict[str, str | None] | None

--- a/api/schema/out.py
+++ b/api/schema/out.py
@@ -60,3 +60,14 @@ class HealthResponse(Schema):
 
 class PingResponse(Schema):
     status: str = 'ok'
+
+
+class GroupResponse(Schema):
+    name: str
+    description: str | None
+    data: dict[str, str | None] | None
+
+
+class GroupsResponse(Schema):
+    groups: list[GroupResponse]
+    count: int

--- a/api/schema/out.py
+++ b/api/schema/out.py
@@ -66,6 +66,8 @@ class GroupResponse(Schema):
     name: str
     description: str | None
     data: dict[str, str | None] | None
+    created_at: datetime | None
+    updated_at: datetime | None
 
 
 class GroupsResponse(Schema):

--- a/examples/data_loader/load_db.py
+++ b/examples/data_loader/load_db.py
@@ -103,7 +103,7 @@ def load_db(intent, merged):
 
             for field in remaining_fields:
                 cluster_data_field = get_or_create(
-                    clus_data_field_cache, models.ClusterDataField, field
+                    clus_data_field_cache, models.CustomDataField, field
                 )
 
                 value = row[field].strip()
@@ -192,10 +192,10 @@ def create_validators():
     )
 
     # @formatter:off
-    models.ClusterDataFieldValidatorAssignment.objects.bulk_create(
+    models.CustomDataFieldValidatorAssignment.objects.bulk_create(
         [
-            models.ClusterDataFieldValidatorAssignment(
-                field=models.ClusterDataField.objects.get(name=assignment['field']),
+            models.CustomDataFieldValidatorAssignment(
+                field=models.CustomDataField.objects.get(name=assignment['field']),
                 validator=models.Validator.objects.get(name=assignment['validator'])
             ) for assignment in [
                 {
@@ -220,9 +220,9 @@ def delete_all_objects():
 
     for model in [
         models.ValidatorAssignment,
-        models.ClusterDataFieldValidatorAssignment,
+        models.CustomDataFieldValidatorAssignment,
         models.Validator,
-        models.ClusterDataField,
+        models.CustomDataField,
         models.ClusterData,
         models.ClusterIntent,
         models.ClusterFleetLabel,

--- a/parameter_store/admin.py
+++ b/parameter_store/admin.py
@@ -20,9 +20,10 @@ from django.contrib import admin
 from guardian.admin import GuardedModelAdmin
 
 from .admin_inlines import ClusterIntentInline, ClusterTagInline, ClusterFleetLabelsInline, \
-    ClusterDataInline
+    ClusterDataInline, GroupDataInline
 from .models import Cluster, ClusterIntent, ClusterTag, ClusterFleetLabel, Group, Tag, Validator, \
-    ValidatorAssignment, ClusterData, CustomDataField, CustomDataFieldValidatorAssignment
+    ValidatorAssignment, ClusterData, CustomDataField, CustomDataFieldValidatorAssignment, \
+    GroupData
 
 
 class ParamStoreAdmin(usites.UnfoldAdminSite):
@@ -95,7 +96,7 @@ class ClusterAdmin(GuardedModelAdmin, uadmin.ModelAdmin):
 
 @admin.register(Group, site=param_admin_site)
 class GroupAdmin(GuardedModelAdmin, uadmin.ModelAdmin):
-    # inlines = [GroupDataInline]
+    inlines = [GroupDataInline]
     list_display = ['name']
     sortable_by = ['name']
     ordering = ['name']
@@ -154,6 +155,18 @@ class ClusterDataAdmin(GuardedModelAdmin, uadmin.ModelAdmin):
 
     def get_queryset(self, request):
         return super().get_queryset(request).select_related('cluster', 'field')
+
+    def has_module_permission(self, request, **kwargs):
+        # Return False to hide the model from the admin
+        return False
+
+
+@admin.register(GroupData, site=param_admin_site)
+class GroupDataAdmin(GuardedModelAdmin, uadmin.ModelAdmin):
+    readonly_fields = ('created_at', 'updated_at')
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related('group', 'field')
 
     def has_module_permission(self, request, **kwargs):
         # Return False to hide the model from the admin

--- a/parameter_store/admin_inlines.py
+++ b/parameter_store/admin_inlines.py
@@ -1,0 +1,112 @@
+from django import forms
+from django.core.cache import cache
+from django.core.exceptions import ValidationError
+from django.forms import ModelForm
+from unfold import admin as uadmin
+
+from parameter_store.models import ClusterIntent, Tag, ClusterTag, ClusterFleetLabel, \
+    CustomDataField, ClusterData, GroupData
+
+
+class ClusterIntentInline(uadmin.StackedInline):
+    model = ClusterIntent
+    extra = 0
+    parent_link = True
+
+
+def get_tag_choices():
+    """Caches Tag choices for inline forms."""
+    cache_key = 'tag_choices_inline'  # Distinct cache key for inlines
+    choices = cache.get(cache_key)
+    if choices is None:
+        choices = list(Tag.objects.values_list('id', 'name'))
+        cache.set(cache_key, choices, timeout=300)  # Cache for 5 minutes
+    return choices
+
+
+class ClusterTagInlineForm(forms.ModelForm):
+    tag = forms.ChoiceField(choices=get_tag_choices)
+
+    class Meta:
+        model = ClusterTag
+        fields = '__all__'
+
+    def clean_tag(self):
+        field_id = self.cleaned_data.get('tag')
+        if field_id:
+            try:
+                return Tag.objects.get(pk=field_id)
+            except Tag.DoesNotExist:
+                raise ValidationError("Invalid Tag.")
+        return None
+
+
+class ClusterTagInline(uadmin.TabularInline):
+    model = ClusterTag
+    form = ClusterTagInlineForm
+    extra = 0
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related('cluster', 'tag')
+
+
+class ClusterFleetLabelsInline(uadmin.TabularInline):
+    model = ClusterFleetLabel
+    extra = 0
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related('cluster')
+
+
+def get_data_field_choices():
+    """Caches ClusterDataField choices."""
+    cache_key = 'cluster_data_field_choices'
+    choices = cache.get(cache_key)
+    if choices is None:
+        choices = list(
+            CustomDataField.objects.values_list('id', 'name'))
+        cache.set(cache_key, choices, timeout=300)  # Cached for 5 minutes
+    return choices
+
+
+class DataInlineForm(ModelForm):
+    field = forms.ChoiceField(choices=get_data_field_choices)
+
+    def clean_field(self):
+        field_id = self.cleaned_data.get('field')
+        if field_id:
+            try:
+                return CustomDataField.objects.get(pk=field_id)
+            except CustomDataField.DoesNotExist:
+                raise ValidationError("Invalid CustomDataField.")
+        return None
+
+
+class ClusterDataInlineForm(DataInlineForm):
+    class Meta:
+        model = ClusterData
+        fields = '__all__'
+
+
+class ClusterDataInline(uadmin.TabularInline):
+    model = ClusterData
+    form = ClusterDataInlineForm
+    extra = 0
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related('cluster', 'field')
+
+
+class GroupDataInlineForm(DataInlineForm):
+    class Meta:
+        model = GroupData
+        fields = '__all__'
+
+
+class GroupDataInline(uadmin.TabularInline):
+    model = GroupData
+    form = GroupDataInlineForm
+    extra = 0
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related('group', 'field')

--- a/parameter_store/models.py
+++ b/parameter_store/models.py
@@ -396,12 +396,7 @@ class ClusterData(CustomDataValidatingModel):
             models.UniqueConstraint(fields=['cluster', 'field'], name='unique_cluster_field')
         ]
 
-    cluster = models.ForeignKey(
-        Cluster,
-        null=True,
-        blank=True,
-        on_delete=models.CASCADE,
-        related_name="cluster_data")
+    cluster = models.ForeignKey(Cluster, on_delete=models.CASCADE, related_name="cluster_data")
     field = models.ForeignKey(CustomDataField, on_delete=models.CASCADE)
     value = models.CharField(max_length=1024, null=True, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
@@ -419,12 +414,7 @@ class GroupData(CustomDataValidatingModel):
             models.UniqueConstraint(fields=['group', 'field'], name='unique_group_field')
         ]
 
-    group = models.ForeignKey(
-        Group,
-        null=True,
-        blank=True,
-        on_delete=models.CASCADE,
-        related_name="group_data")
+    group = models.ForeignKey(Group, on_delete=models.CASCADE, related_name="group_data")
     field = models.ForeignKey(CustomDataField, on_delete=models.CASCADE)
     value = models.CharField(max_length=1024, null=True, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)

--- a/parameter_store/models.py
+++ b/parameter_store/models.py
@@ -115,12 +115,18 @@ class ClusterManager(models.Manager):
     #     return super().get_queryset()
 
     def with_related(self):
+        """
+
+        Returns:
+
+        """
         return (
             self.get_queryset()
             .select_related('group', 'intent')
             .prefetch_related(
                 'tags',
                 'fleet_labels',
+                'secondary_groups',
                 Prefetch(
                     'data',
                     queryset=ClusterData.objects.select_related('field')
@@ -133,6 +139,7 @@ class Cluster(DynamicValidatingModel):
     name = models.CharField(db_index=True, max_length=30, blank=False, unique=True, null=False)
     description = models.CharField(max_length=255, null=True, blank=True)
     group = models.ForeignKey(Group, on_delete=models.DO_NOTHING)
+    secondary_groups = models.ManyToManyField(Group, related_name='secondary_clusters')
     tags = models.ManyToManyField(
         'Tag',
         through='ClusterTag',

--- a/parameter_store/models.py
+++ b/parameter_store/models.py
@@ -110,6 +110,17 @@ class Group(DynamicValidatingModel):
         return self.name
 
 
+class Tag(DynamicValidatingModel):
+    name = models.CharField(max_length=30, blank=False, unique=True, null=False,
+                            verbose_name='tag name')
+    description = models.CharField(max_length=255, null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    def __str__(self):
+        return self.name
+
+
 class ClusterManager(models.Manager):
     # def get_queryset(self):
     #     return super().get_queryset()
@@ -128,7 +139,7 @@ class ClusterManager(models.Manager):
                 'fleet_labels',
                 'secondary_groups',
                 Prefetch(
-                    'data',
+                    'cluster_data',
                     queryset=ClusterData.objects.select_related('field')
                 )
             )
@@ -164,17 +175,6 @@ class Cluster(DynamicValidatingModel):
     @property
     def data_list(self):
         return self.data.all()
-
-
-class Tag(DynamicValidatingModel):
-    name = models.CharField(max_length=30, blank=False, unique=True, null=False,
-                            verbose_name='tag name')
-    description = models.CharField(max_length=255, null=True, blank=True)
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
-
-    def __str__(self):
-        return self.name
 
 
 class ClusterTag(DynamicValidatingModel):
@@ -328,6 +328,112 @@ class ClusterFleetLabel(DynamicValidatingModel):
         return f'{self.cluster.name} - "{self.key}" = "{self.value}"'
 
 
+class CustomDataField(models.Model):
+    class Meta:
+        verbose_name = 'Custom Data Field'
+        verbose_name_plural = 'Custom Data Fields'
+
+    name = models.CharField(max_length=64, blank=False, unique=True, null=False)
+    description = models.CharField(max_length=255, null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    def __str__(self):
+        return self.name
+
+
+class CustomDataValidatingModel(models.Model):
+    class Meta:
+        abstract = True
+
+    def clean(self, validator_assignment_model=None) -> None:
+        """
+        Cleans and validates the current instance against a set of validators.
+
+        The method first logs the process of validation, then retrieves all
+        `ValidatorAssignment` instances that are associated with the current
+        class by filtering on its module and name. Each validator is instantiated
+        with its parameters, and then applied on the specified model field.
+        Any validation errors are collected and, if any are found, a
+        `ValidationError` is raised with all collected errors.
+
+        :raises TypeError: If the validator is instantiated with invalid
+            parameters.
+        :raises AttributeError: If a `ValidatorAssignment` references an
+            invalid field for the model.
+        :raises ValidationError: If any of the validators fail validation.
+        """
+        logger.debug(f'Validating {self.__class__.__name__} with parameters: {self.__dict__!r} ')
+        super().clean()
+
+        errors = defaultdict(list)
+        for va in CustomDataFieldValidatorAssignment.objects.filter(field=self.field.id):
+            Validator = get_class_from_full_path(va.validator.validator)
+
+            try:
+                validator = Validator(**va.validator.parameters)
+            except TypeError:
+                logger.error(
+                    f'Invalid parameters for validator '
+                    f'{va.validator.name}: {va.validator.parameters}')
+                raise
+
+            try:
+                validator.validate(self.value)
+            except ValidationError as e:
+                logger.info("Validation error", e)
+                errors['field'].append(e)
+
+        if errors:
+            raise ValidationError(errors)
+
+
+class ClusterData(CustomDataValidatingModel):
+    class Meta:
+        verbose_name = 'Cluster Custom Data'
+        verbose_name_plural = 'Cluster Custom Data'
+        constraints = [
+            models.UniqueConstraint(fields=['cluster', 'field'], name='unique_cluster_field')
+        ]
+
+    cluster = models.ForeignKey(
+        Cluster,
+        null=True,
+        blank=True,
+        on_delete=models.CASCADE,
+        related_name="cluster_data")
+    field = models.ForeignKey(CustomDataField, on_delete=models.CASCADE)
+    value = models.CharField(max_length=1024, null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    def __str__(self):
+        return f'{self.cluster.name} - "{self.field.name}" = "{self.value}"'
+
+
+class GroupData(CustomDataValidatingModel):
+    class Meta:
+        verbose_name = 'Group Custom Data'
+        verbose_name_plural = 'Group Custom Data'
+        constraints = [
+            models.UniqueConstraint(fields=['group', 'field'], name='unique_group_field')
+        ]
+
+    group = models.ForeignKey(
+        Group,
+        null=True,
+        blank=True,
+        on_delete=models.CASCADE,
+        related_name="group_data")
+    field = models.ForeignKey(CustomDataField, on_delete=models.CASCADE)
+    value = models.CharField(max_length=1024, null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    def __str__(self):
+        return f'{self.group.name} - "{self.field.name}" = "{self.value}"'
+
+
 def get_validator_choices():
     """Returns a list of tuples representing custom validator classes.
     """
@@ -434,8 +540,8 @@ class ValidatorAssignment(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
 
     class Meta:
-        verbose_name = "Standard Validator Assignment"
-        verbose_name_plural = "Standard Validator Assignments"
+        verbose_name = "Standard Data Validator Assignment"
+        verbose_name_plural = "Standard Data Validator Assignments"
         constraints = [
             models.UniqueConstraint(
                 fields=['model', 'model_field', 'validator'], name='unique_model_field_validator')
@@ -453,21 +559,7 @@ class ValidatorAssignment(models.Model):
             })
 
 
-class ClusterDataField(models.Model):
-    class Meta:
-        verbose_name = 'Cluster Custom Data Field'
-        verbose_name_plural = 'Cluster Custom Data Fields'
-
-    name = models.CharField(max_length=64, blank=False, unique=True, null=False)
-    description = models.CharField(max_length=255, null=True, blank=True)
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
-
-    def __str__(self):
-        return self.name
-
-
-class ClusterDataFieldValidatorAssignment(models.Model):
+class CustomDataFieldValidatorAssignment(models.Model):
     class Meta:
         verbose_name = 'Custom Data Validator Assignment'
         verbose_name_plural = 'Custom Data Validator Assignments'
@@ -475,70 +567,10 @@ class ClusterDataFieldValidatorAssignment(models.Model):
             models.UniqueConstraint(fields=['field', 'validator'], name='unique_field_validator')
         ]
 
-    field = models.ForeignKey(ClusterDataField, on_delete=models.DO_NOTHING)
+    field = models.ForeignKey(CustomDataField, on_delete=models.DO_NOTHING)
     validator = models.ForeignKey(Validator, on_delete=models.DO_NOTHING)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
     def __str__(self):
         return f'Field "{self.field.name}" - Validator "{self.validator.name}"'
-
-
-class ClusterData(models.Model):
-    class Meta:
-        verbose_name = 'Cluster Custom Data'
-        verbose_name_plural = 'Cluster Custom Data'
-        constraints = [
-            models.UniqueConstraint(fields=['cluster', 'field'], name='unique_cluster_field')
-        ]
-
-    cluster = models.ForeignKey(Cluster, on_delete=models.CASCADE, related_name="data")
-    field = models.ForeignKey(ClusterDataField, on_delete=models.CASCADE)
-    value = models.CharField(max_length=1024, null=True, blank=True)
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
-
-    def __str__(self):
-        return f'{self.cluster.name} - "{self.field.name}" = "{self.value}"'
-
-    def clean(self, validator_assignment_model=None) -> None:
-        """
-        Cleans and validates the current instance against a set of validators.
-
-        The method first logs the process of validation, then retrieves all
-        `ValidatorAssignment` instances that are associated with the current
-        class by filtering on its module and name. Each validator is instantiated
-        with its parameters, and then applied on the specified model field.
-        Any validation errors are collected and, if any are found, a
-        `ValidationError` is raised with all collected errors.
-
-        :raises TypeError: If the validator is instantiated with invalid
-            parameters.
-        :raises AttributeError: If a `ValidatorAssignment` references an
-            invalid field for the model.
-        :raises ValidationError: If any of the validators fail validation.
-        """
-
-        logger.debug(f'Validating {self.__class__.__name__} with parameters: {self.__dict__!r} ')
-        super().clean()
-
-        errors = defaultdict(list)
-        for va in ClusterDataFieldValidatorAssignment.objects.filter(field=self.field.id):
-            Validator = get_class_from_full_path(va.validator.validator)
-
-            try:
-                validator = Validator(**va.validator.parameters)
-            except TypeError:
-                logger.error(
-                    f'Invalid parameters for validator '
-                    f'{va.validator.name}: {va.validator.parameters}')
-                raise
-
-            try:
-                validator.validate(self.value)
-            except ValidationError as e:
-                logger.info("Validation error", e)
-                errors['field'].append(e)
-
-        if errors:
-            raise ValidationError(errors)

--- a/parameter_store/signals.py
+++ b/parameter_store/signals.py
@@ -2,7 +2,7 @@ from django.core.cache import cache
 from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 
-from .models import ClusterDataField, Tag, ClusterTag, ClusterIntent, \
+from .models import CustomDataField, Tag, ClusterTag, ClusterIntent, \
     ClusterFleetLabel, ClusterData, Cluster
 
 
@@ -79,11 +79,11 @@ def invalidate_tag_cache_on_delete(sender, **kwargs):
     cache.delete('tag_choices_inline')
 
 
-@receiver(post_save, sender=ClusterDataField)
+@receiver(post_save, sender=CustomDataField)
 def invalidate_cluster_data_field_choices_on_save(sender, instance, **kwargs):
     cache.delete('cluster_data_field_choices')
 
 
-@receiver(post_delete, sender=ClusterDataField)
+@receiver(post_delete, sender=CustomDataField)
 def invalidate_cluster_data_field_choices_on_delete(sender, instance, **kwargs):
     cache.delete('cluster_data_field_choices')

--- a/parameter_store/signals.py
+++ b/parameter_store/signals.py
@@ -1,53 +1,51 @@
+import datetime
+from typing import Type
+
 from django.core.cache import cache
+from django.db.models import Model
 from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
+from django.utils import timezone
 
 from .models import CustomDataField, Tag, ClusterTag, ClusterIntent, \
-    ClusterFleetLabel, ClusterData, Cluster
+    ClusterFleetLabel, ClusterData, Cluster, GroupData, Group
 
 
-def update_cluster_timestamp(cluster, updated_at):
-    """Updates the 'updated_at' timestamp on a given Cluster instance.
+def update_timestamp(model: Type[Model], parent_instance: Group | Cluster,
+                     updated_at: datetime.datetime):
+    """Updates the 'updated_at' timestamp on a given Cluster or Group instance.
 
     Args:
-        updated_at: datetime
+        model: model/table to search for parent object
+        parent_instance: related object that we are searching to update
+        updated_at: datetime of change
     """
-    if cluster:
-        Cluster.objects.filter(pk=cluster.pk).update(updated_at=updated_at)
+    if parent_instance:
+        model.objects.filter(pk=parent_instance.pk).update(updated_at=updated_at)
 
 
-@receiver(post_save, sender=ClusterTag)
-@receiver(post_save, sender=ClusterIntent)
-@receiver(post_save, sender=ClusterFleetLabel)
-@receiver(post_save, sender=ClusterData)
-def related_object_saved(sender, instance, **kwargs):
-    """ Listens for save events on models with FK/O2O to Cluster.
-    Updates the Cluster's updated_at timestamp.
+@receiver((post_save, post_delete), sender=ClusterTag)
+@receiver((post_save, post_delete), sender=ClusterIntent)
+@receiver((post_save, post_delete), sender=ClusterFleetLabel)
+@receiver((post_save, post_delete), sender=ClusterData)
+@receiver((post_save, post_delete), sender=GroupData)
+def related_object_saved(sender, *, instance, **kwargs):
+    """ Listens for save and delete events on models with FK/O2O to Cluster.
+    Updates the Cluster or Group's updated_at timestamp.
     """
-    cluster = None
+    this = None
     if hasattr(instance, 'cluster') and instance.cluster:
-        cluster = instance.cluster
+        this = instance.cluster
+    elif hasattr(instance, 'group') and instance.group:
+        this = instance.group
 
-    if cluster:
-        update_cluster_timestamp(cluster, instance.updated_at)
+    upd_at = timezone.now() if kwargs.get('signal') else instance.updated_at
 
-
-@receiver(post_save, sender=ClusterTag)
-@receiver(post_save, sender=ClusterIntent)
-@receiver(post_save, sender=ClusterFleetLabel)
-@receiver(post_save, sender=ClusterData)
-def related_object_deleted(sender, instance, **kwargs):
-    """  Listens for delete events on models with FK/O2O to Cluster.
-    Updates the Cluster's updated_at timestamp.
-    """
-    cluster = None
-    if hasattr(instance, 'cluster') and instance.cluster:
-        # Note: On deletion, the related object might already be partially gone,
-        # but the foreign key reference should still be accessible here.
-        cluster = instance.cluster
-
-    if cluster:
-        update_cluster_timestamp(cluster, instance.updated_at)
+    match this:
+        case Cluster():
+            update_timestamp(Cluster, this, upd_at)
+        case Group():
+            update_timestamp(Group, this, upd_at)
 
 
 # This is intentionally dark code; leaving this commented out.


### PR DESCRIPTION
Secondary groups are added with a many-to-many relationship.  Clusters have a single primary group, defined as the primary container and configuration boundary, but may now belong to arbitrarily many secondary groups which convey purposeful configuration boundaries within that secondary group context.  Adds support for group custom data in the UI and API.

feat: group downstream custom data changes propagate to updated_at field in object and are output via API

feat: add API endpoints to get a single group or cluster by name

feat: hide tables from UI for cluster-related data; fixes #40

refactor(admin): move all Inlines to `admin_inlines.py`