### PR TITLE
feat: Implement ChangeSet Management in Django Admin

### DIFF
--- a/parameter_store/admin.py
+++ b/parameter_store/admin.py
@@ -227,6 +227,15 @@ class ChangeSetAdmin(GuardedModelAdmin, uadmin.ModelAdmin):
         super().save_model(request, obj, form, change)
 
     def commit_changeset(self, request, queryset):
+        """Commits the selected changesets.
+
+        This action commits the selected changesets, making the changes live. Only changesets in the DRAFT state can be
+        committed.
+
+        Args:
+            request: The HttpRequest object.
+            queryset: The queryset of selected ChangeSet objects.
+        """
         from django.db import transaction
         from django.utils import timezone
 
@@ -278,6 +287,15 @@ class ChangeSetAdmin(GuardedModelAdmin, uadmin.ModelAdmin):
     commit_changeset.short_description = "Commit selected changesets"
 
     def discard_changeset(self, request, queryset):
+        """Discards the selected changesets.
+
+        This action discards the selected changesets, deleting all associated draft data. Only changesets in the DRAFT
+        state can be discarded.
+
+        Args:
+            request: The HttpRequest object.
+            queryset: The queryset of selected ChangeSet objects.
+        """
         from django.db import transaction
 
         from .models import Cluster, ClusterData, ClusterFleetLabel, ClusterIntent, ClusterTag, Group, GroupData
@@ -312,6 +330,15 @@ class ChangeSetAdmin(GuardedModelAdmin, uadmin.ModelAdmin):
     discard_changeset.short_description = "Discard selected changesets"
 
     def coalesce_changesets(self, request, queryset):
+        """Coalesces multiple changesets into a single one.
+
+        This action merges multiple changesets into a single target changeset. The target changeset is the first one
+        selected. All other selected changesets will be merged into the target changeset and then deleted.
+
+        Args:
+            request: The HttpRequest object.
+            queryset: The queryset of selected ChangeSet objects.
+        """
         from django.db import transaction
 
         from .models import Cluster, ClusterData, ClusterFleetLabel, ClusterIntent, ClusterTag, Group, GroupData

--- a/parameter_store/admin.py
+++ b/parameter_store/admin.py
@@ -255,8 +255,7 @@ class ChangeSetAdmin(GuardedModelAdmin, uadmin.ModelAdmin):
                         draft_entity.is_live = True
                         draft_entity.changeset_id = None
                         draft_entity.is_locked = False
-                        # Assuming locked_by_changeset is the name of the field. The document uses locked_by_changeset, but the model has changeset_id.
-                        # I will assume that when is_locked is false, the changeset_id should be null.
+                        # When is_locked is false, the changeset_id should be null.
                         draft_entity.save()
 
                 # Process child entities

--- a/parameter_store/context_processors.py
+++ b/parameter_store/context_processors.py
@@ -4,8 +4,16 @@ from .models import ChangeSet
 
 
 def custom_header_links(request):
-    """
-    Adds custom links to the userlinks header area.
+    """Renders a changeset selector in the header.
+
+    This context processor renders a template to display a changeset selector in the header. It also handles the logic
+    for setting the active changeset in the session.
+
+    Args:
+        request: The HttpRequest object.
+
+    Returns:
+        A dictionary containing the rendered changeset selector.
     """
     active_changeset_id = request.session.get("active_changeset_id")
     active_changeset = None

--- a/parameter_store/context_processors.py
+++ b/parameter_store/context_processors.py
@@ -1,7 +1,30 @@
+from django.template.loader import render_to_string
+
+from .models import ChangeSet
+
+
 def custom_header_links(request):
     """
     Adds custom links to the userlinks header area.
     """
+    active_changeset_id = request.session.get("active_changeset_id")
+    active_changeset = None
+    if active_changeset_id:
+        try:
+            active_changeset = ChangeSet.objects.get(id=active_changeset_id)
+        except ChangeSet.DoesNotExist:
+            pass
+
+    draft_changesets = ChangeSet.objects.filter(status=ChangeSet.Status.DRAFT)
+
+    if request.GET.get("active_changeset"):
+        request.session["active_changeset_id"] = request.GET.get("active_changeset")
+
+    context = {
+        "active_changeset": active_changeset,
+        "draft_changesets": draft_changesets,
+    }
+
     return {
-        "changeset_icon": '<a href="/params/parameter_store/changeset/" title="ChangeSets" class="flex items-center justify-center w-10 h-10"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-replace-all-icon lucide-replace-all"><path d="M14 14a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2"/><path d="M14 4a2 2 0 0 1 2-2"/><path d="M16 10a2 2 0 0 1-2-2"/><path d="M20 14a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2"/><path d="M20 2a2 2 0 0 1 2 2"/><path d="M22 8a2 2 0 0 1-2 2"/><path d="m3 7 3 3 3-3"/><path d="M6 10V5a 3 3 0 0 1 3-3h1"/><rect x="2" y="14" width="8" height="8" rx="2"/></svg></a>',
+        "changeset_icon": render_to_string("unfold/helpers/changeset_selector.html", context),
     }

--- a/parameter_store/settings.py
+++ b/parameter_store/settings.py
@@ -91,11 +91,6 @@ ROOT_URLCONF = "parameter_store.urls"
 
 TEMPLATES = [
     {
-        "BACKEND": "django.template.backends.jinja2.Jinja2",
-        "DIRS": [os.path.join(BASE_DIR, "templates")],
-        "APP_DIRS": True,
-    },
-    {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "DIRS": [os.path.join(BASE_DIR, "templates")],
         "APP_DIRS": True,
@@ -108,6 +103,11 @@ TEMPLATES = [
                 "parameter_store.context_processors.custom_header_links",
             ],
         },
+    },
+    {
+        "BACKEND": "django.template.backends.jinja2.Jinja2",
+        "DIRS": [os.path.join(BASE_DIR, "templates")],
+        "APP_DIRS": True,
     },
 ]
 

--- a/templates/unfold/helpers/changeset_selector.html
+++ b/templates/unfold/helpers/changeset_selector.html
@@ -1,0 +1,28 @@
+{% load i18n %}
+<div class="flex items-center">
+    <div class="relative" data-headlessui-state="">
+        <button class="flex items-center justify-center w-10 h-10" type="button" aria-expanded="false" data-headlessui-state="" id="headlessui-menu-button-1">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-replace-all-icon lucide-replace-all"><path d="M14 14a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2"/><path d="M14 4a2 2 0 0 1 2-2"/><path d="M16 10a2 2 0 0 1-2-2"/><path d="M20 14a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2"/><path d="M20 2a2 2 0 0 1 2 2"/><path d="M22 8a2 2 0 0 1-2 2"/><path d="m3 7 3 3 3-3"/><path d="M6 10V5a 3 3 0 0 1 3-3h1"/><rect x="2" y="14" width="8" height="8" rx="2"/></svg>
+        </button>
+        <div class="absolute right-0 w-56 mt-2 origin-top-right bg-white rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none" aria-orientation="vertical" aria-labelledby="headlessui-menu-button-1" role="menu" tabindex="0" data-headlessui-state="open" style="transform-origin: top right;">
+            <div class="py-1" role="none">
+                <div class="px-4 py-2 text-sm text-gray-700 border-b" role="none">
+                    <p class="font-semibold">{% trans "Active ChangeSet" %}</p>
+                    <p>{{ active_changeset.name|default:"None" }}</p>
+                </div>
+                {% for changeset in draft_changesets %}
+                    <a href="?active_changeset={{ changeset.id }}" class="block px-4 py-2 text-sm text-gray-700 {% if changeset.id == active_changeset.id %} bg-gray-100 {% endif %}" role="menuitem" tabindex="-1" id="headlessui-menu-item-{{ forloop.counter }}">
+                        {{ changeset.name }}
+                    </a>
+                {% empty %}
+                    <p class="px-4 py-2 text-sm text-gray-500">{% trans "No draft changesets" %}</p>
+                {% endfor %}
+                <div class="border-t">
+                    <a href="{% url 'param_admin:parameter_store_changeset_add' %}" class="block px-4 py-2 text-sm text-gray-700" role="menuitem" tabindex="-1" id="headlessui-menu-item-new">
+                        {% trans "Create new changeset" %}
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/unfold/helpers/changeset_selector.html
+++ b/templates/unfold/helpers/changeset_selector.html
@@ -11,22 +11,25 @@
              x-transition:leave="transition ease-in duration-75"
              x-transition:leave-start="transform opacity-100 scale-100"
              x-transition:leave-end="transform opacity-0 scale-95"
-             class="absolute right-0 w-56 mt-2 origin-top-right bg-white rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
+             class="absolute right-0 mt-2 origin-top-right bg-white rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
              style="display: none;"
              aria-orientation="vertical"
              role="menu">
-            <div class="py-1" role="none">
+            <div class="py-1 w-40" role="none">
                 <div class="px-4 py-2 text-sm text-gray-700 border-b" role="none">
                     <p class="font-semibold">{% trans "Active ChangeSet" %}</p>
                     <p>{{ active_changeset.name|default:"None" }}</p>
                 </div>
-                {% for changeset in draft_changesets %}
-                    <a href="?active_changeset={{ changeset.id }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 {% if changeset.id == active_changeset.id %} bg-gray-100 {% endif %}" role="menuitem">
-                        {{ changeset.name }}
-                    </a>
-                {% empty %}
-                    <p class="px-4 py-2 text-sm text-gray-500">{% trans "No draft ChangeSets" %}</p>
-                {% endfor %}
+                <div class="px-4 py-4 text-sm text-gray-700 border-b" role="none">
+                    <p class="font-semibold">{% trans "Draft ChangeSets" %}</p>
+                    {% for changeset in draft_changesets %}
+                        <a href="?active_changeset={{ changeset.id }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 {% if changeset.id == active_changeset.id %} bg-gray-100 {% endif %}" role="menuitem">
+                            {{ changeset.name }}
+                        </a>
+                    {% empty %}
+                        <p class="px-4 py-2 text-sm text-gray-500">{% trans "No draft ChangeSets" %}</p>
+                    {% endfor %}
+                </div>
                 <div class="border-t">
                     <a href="{% url 'param_admin:parameter_store_changeset_add' %}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" role="menuitem">
                         {% trans "Create new ChangeSet" %}

--- a/templates/unfold/helpers/changeset_selector.html
+++ b/templates/unfold/helpers/changeset_selector.html
@@ -1,40 +1,38 @@
 {% load i18n %}
 <div class="flex items-center">
     <div x-data="{ open: false }" @click.outside="open = false" @keydown.escape.window="open = false" class="relative">
-        <button @click="open = !open" class="flex items-center justify-center w-10 h-10" type="button" aria-expanded="false" title="Active ChangeSets">
+        <button @click="open = !open" class="block cursor-pointer h-[18px] hover:text-base-700 dark:hover:text-base-200" type="button" aria-expanded="false" title="Active ChangeSets">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-replace-all-icon lucide-replace-all"><path d="M14 14a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2"/><path d="M14 4a2 2 0 0 1 2-2"/><path d="M16 10a2 2 0 0 1-2-2"/><path d="M20 14a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2"/><path d="M20 2a2 2 0 0 1 2 2"/><path d="M22 8a2 2 0 0 1-2 2"/><path d="m3 7 3 3 3-3"/><path d="M6 10V5a 3 3 0 0 1 3-3h1"/><rect x="2" y="14" width="8" height="8" rx="2"/></svg>
         </button>
         <div x-show="open"
-             x-transition:enter="transition ease-out duration-100"
-             x-transition:enter-start="transform opacity-0 scale-95"
-             x-transition:enter-end="transform opacity-100 scale-100"
-             x-transition:leave="transition ease-in duration-75"
-             x-transition:leave-start="transform opacity-100 scale-100"
-             x-transition:leave-end="transform opacity-0 scale-95"
-             class="absolute right-0 mt-2 origin-top-right bg-white rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
+             x-transition
+             x-on:click.outside="open = false"
+             class="absolute bg-white border border-base-200 flex flex-col leading-none py-1 -right-2 rounded-default shadow-lg top-7 w-52 z-50 dark:bg-base-800 dark:border-base-700"
              style="display: none;"
              aria-orientation="vertical"
              role="menu">
-            <div class="py-1 w-40" role="none">
-                <div class="px-4 py-2 text-sm text-gray-700 border-b" role="none">
+            <div class="border-b border-base-200 flex flex-row shrink-0 items-start justify-start mb-1 pb-1 dark:border-base-700" role="none">
+                <span class="block mx-1 px-3 py-2 truncate">
                     <p class="font-semibold">{% trans "Active ChangeSet" %}</p>
                     <p>{{ active_changeset.name|default:"None" }}</p>
-                </div>
-                <div class="px-4 py-4 text-sm text-gray-700 border-b" role="none">
+                </span>
+            </div>
+            <div class="flex flex-row shrink-0 items-start justify-start mb-1 pb-1" role="none">
+                <span class="block mx-1 px-3 py-2 truncate">
                     <p class="font-semibold">{% trans "Draft ChangeSets" %}</p>
                     {% for changeset in draft_changesets %}
-                        <a href="?active_changeset={{ changeset.id }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 {% if changeset.id == active_changeset.id %} bg-gray-100 {% endif %}" role="menuitem">
+                        <a href="?active_changeset={{ changeset.id }}" class="mx-1 px-3 py-2 rounded-default hover:bg-base-100 hover:text-base-700 dark:hover:bg-base-700 dark:hover:text-base-200 {% if changeset.id == active_changeset.id %} bg-base-100 {% endif %}" role="menuitem">
                             {{ changeset.name }}
                         </a>
                     {% empty %}
-                        <p class="px-4 py-2 text-sm text-gray-500">{% trans "No draft ChangeSets" %}</p>
+                        <p class="mx-1 px-3 py-2 text-sm text-gray-500">{% trans "No draft ChangeSets" %}</p>
                     {% endfor %}
-                </div>
-                <div class="border-t">
-                    <a href="{% url 'param_admin:parameter_store_changeset_add' %}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" role="menuitem">
-                        {% trans "Create new ChangeSet" %}
-                    </a>
-                </div>
+                </span>
+            </div>
+            <div class="border-t border-base-200 mt-1 pt-1 dark:border-base-700">
+                <a href="{% url 'param_admin:parameter_store_changeset_add' %}" class="mx-1 px-3 py-2 rounded-default hover:bg-base-100 hover:text-base-700 dark:hover:bg-base-700 dark:hover:text-base-200" role="menuitem">
+                    {% trans "Create new ChangeSet" %}
+                </a>
             </div>
         </div>
     </div>

--- a/templates/unfold/helpers/changeset_selector.html
+++ b/templates/unfold/helpers/changeset_selector.html
@@ -1,25 +1,35 @@
 {% load i18n %}
 <div class="flex items-center">
-    <div class="relative" data-headlessui-state="">
-        <button class="flex items-center justify-center w-10 h-10" type="button" aria-expanded="false" data-headlessui-state="" id="headlessui-menu-button-1">
+    <div x-data="{ open: false }" @click.outside="open = false" @keydown.escape.window="open = false" class="relative">
+        <button @click="open = !open" class="flex items-center justify-center w-10 h-10" type="button" aria-expanded="false" title="Active ChangeSets">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-replace-all-icon lucide-replace-all"><path d="M14 14a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2"/><path d="M14 4a2 2 0 0 1 2-2"/><path d="M16 10a2 2 0 0 1-2-2"/><path d="M20 14a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2"/><path d="M20 2a2 2 0 0 1 2 2"/><path d="M22 8a2 2 0 0 1-2 2"/><path d="m3 7 3 3 3-3"/><path d="M6 10V5a 3 3 0 0 1 3-3h1"/><rect x="2" y="14" width="8" height="8" rx="2"/></svg>
         </button>
-        <div class="absolute right-0 w-56 mt-2 origin-top-right bg-white rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none" aria-orientation="vertical" aria-labelledby="headlessui-menu-button-1" role="menu" tabindex="0" data-headlessui-state="open" style="transform-origin: top right;">
+        <div x-show="open"
+             x-transition:enter="transition ease-out duration-100"
+             x-transition:enter-start="transform opacity-0 scale-95"
+             x-transition:enter-end="transform opacity-100 scale-100"
+             x-transition:leave="transition ease-in duration-75"
+             x-transition:leave-start="transform opacity-100 scale-100"
+             x-transition:leave-end="transform opacity-0 scale-95"
+             class="absolute right-0 w-56 mt-2 origin-top-right bg-white rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
+             style="display: none;"
+             aria-orientation="vertical"
+             role="menu">
             <div class="py-1" role="none">
                 <div class="px-4 py-2 text-sm text-gray-700 border-b" role="none">
                     <p class="font-semibold">{% trans "Active ChangeSet" %}</p>
                     <p>{{ active_changeset.name|default:"None" }}</p>
                 </div>
                 {% for changeset in draft_changesets %}
-                    <a href="?active_changeset={{ changeset.id }}" class="block px-4 py-2 text-sm text-gray-700 {% if changeset.id == active_changeset.id %} bg-gray-100 {% endif %}" role="menuitem" tabindex="-1" id="headlessui-menu-item-{{ forloop.counter }}">
+                    <a href="?active_changeset={{ changeset.id }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 {% if changeset.id == active_changeset.id %} bg-gray-100 {% endif %}" role="menuitem">
                         {{ changeset.name }}
                     </a>
                 {% empty %}
-                    <p class="px-4 py-2 text-sm text-gray-500">{% trans "No draft changesets" %}</p>
+                    <p class="px-4 py-2 text-sm text-gray-500">{% trans "No draft ChangeSets" %}</p>
                 {% endfor %}
                 <div class="border-t">
-                    <a href="{% url 'param_admin:parameter_store_changeset_add' %}" class="block px-4 py-2 text-sm text-gray-700" role="menuitem" tabindex="-1" id="headlessui-menu-item-new">
-                        {% trans "Create new changeset" %}
+                    <a href="{% url 'param_admin:parameter_store_changeset_add' %}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" role="menuitem">
+                        {% trans "Create new ChangeSet" %}
                     </a>
                 </div>
             </div>


### PR DESCRIPTION
This pull request introduces the core functionality for managing ChangeSets directly within the Django admin interface.

* The ChangeSet model admin now includes custom actions to Commit, Discard, and Coalesce selected draft changesets, enabling the full lifecycle management of changes
* Global Active ChangeSet Selector: A new dropdown menu has been added to the global admin header. This UI element allows users to:
  * View and select their active draft changeset
  * See a list of all their available draft changesets
  * Create a new changeset

* Adjust the template engine order to preference the Django engine
