### PR TITLE
fix: ensure all views use 'Parameter Store'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Edge Parameter Store
+# Parameter Store
 
 <!-- TOC -->
 
-* [Edge Parameter Store](#edge-parameter-store)
+* [Parameter Store](#parameter-store)
     * [Description](#description)
     * [Getting Started](#getting-started)
         * [Preparation](#preparation)
@@ -38,7 +38,7 @@
 
 ## Description
 
-This repository contains the Edge Parameter Store, a Django application that is built to hold parameter data for
+This repository contains the Parameter Store, a Django application that is built to hold parameter data for
 deployments of Google Distributed Cloud Connected clusters where the number of clusters may scale to tens of
 thousands. It is meant to be deployed in support of other solutions and tools (in this Github organization) and as part
 of a broader suite of solutions. This tool conveys the following immediate benefits:
@@ -74,10 +74,12 @@ This section outlines steps that the user must perform
 * [psql client](https://docs.timescale.com/use-timescale/latest/integrations/query-admin/psql/)
   or [pgadmin](https://www.pgadmin.org/download/)
 
-
 ### Bootstrap the EPS GCP Project
 
-The Terraform [README](examples/terraform/README.md) document details the GCP Service Accounts (GSA) that are required for this project. Please ensure you have created a service account for Terraform with the required roles. A [Terraform bootstrap project](./examples/terraform/bootstrap/) has been provided which will create the service account and add the required roles for you.
+The Terraform [README](examples/terraform/README.md) document details the GCP Service Accounts (GSA) that are required
+for this project. Please ensure you have created a service account for Terraform with the required roles.
+A [Terraform bootstrap project](./examples/terraform/bootstrap/) has been provided which will create the service account
+and add the required roles for you.
 
 If you wish to use the [Terraform bootstrap](./examples/terraform/bootstrap/) project, ensure you apply the bootstrap
 configurations before deploying the EPS application.
@@ -89,7 +91,6 @@ terraform init
 terraform apply
 ```
 
-
 #### Configure GCP OAuth Consent Screen
 
 1. Login [GCP Console](https://console.cloud.google.com) and select your target project
@@ -97,13 +98,13 @@ terraform apply
    Configure the OAuth consent screen as External and set the publishing status to In Production.
    ![oauth_consent.gif](./docs/doc_assets/oauth_consent.gif)
 
-
 #### Identify a domain name for the Parameter Store application
 
 Choose a fully qualified domain name for your application. The Terraform provides an opinionated configuration for
 the utilization of your FQDN, creating a managed zone in the deployment project. This assumes you will create a
 delegated
 zone in your application project to which an A-record for the EPS app's load balancer will be created. In doing so, it
+
 wires the application up end-to-end. If this is not your desired configuration, you will need to modify the provided
 Terraform [here](examples/terraform/dns.tf)
 
@@ -154,12 +155,12 @@ it.
     ```
 
 * Both `VERSION` and `APP` are optional.
-  * `VERSION` defaults to `0.1`
-  * `APP` defaults to `parameter-store`.
+    * `VERSION` defaults to `0.1`
+    * `APP` defaults to `parameter-store`.
 
 * The generated image is tagged as `${REPO_HOST}/${PROJECT_ID}/${REPO_FOLDER}/${APP}:v${VERSION}`
   e.g. `us-central-docker.pkg.dev/test-proj-1234/parameter-store/parameter-store:v0.1`
-  * The `latest` tag is always attached to the most recently built image
+    * The `latest` tag is always attached to the most recently built image
 
 ### Deploy GCP Infrastructure
 
@@ -245,10 +246,12 @@ Cloud Run. This is probably a group of users the membership of which is managed 
 This is part of the `_PRIVATE_POOL` substitution in the [cloudbuild.tf](examples/terraform/cloudbuild.tf).
 
 `db_password_key` is a string used as a name or identifier of the secret in Secret Manager that stores the database
-password. This is passed as a substitution `_DATABASE_PASSWORD_KEY` to the [cloudbuild.tf](examples/terraform/cloudbuild.tf).
+password. This is passed as a substitution `_DATABASE_PASSWORD_KEY` to
+the [cloudbuild.tf](examples/terraform/cloudbuild.tf).
 
 `instance_connection_name` is a string used as a connection name for the Cloud SQL instance. This is used by the Cloud
-SQL Proxy to connect to the database. Passed as `_INSTANCE_CONNECTION_NAME` in the [cloudbuild.tf](examples/terraform/cloudbuild.tf).
+SQL Proxy to connect to the database. Passed as `_INSTANCE_CONNECTION_NAME` in
+the [cloudbuild.tf](examples/terraform/cloudbuild.tf).
 
 `artifact_registry_project_id` is a string value for Google Cloud Project ID where the Artifact Registry is located.
 Passed as `_ARTIFACT_REGISTRY_PROJECT_ID` in the [cloudbuild.tf](examples/terraform/cloudbuild.tf).
@@ -458,20 +461,23 @@ sudo -u postgres psql
 3. Create a New Database: Create a new database named eps.
 
 ```sql
-CREATE DATABASE eps;
+CREATE
+DATABASE eps;
 ```
 
 4. Create a New User: Create a new user named eps with a specified password. Replace `your_password` with a strong
    password of your choice.
 
 ```sql
-CREATE USER eps WITH PASSWORD 'your_password';
+CREATE
+USER eps WITH PASSWORD 'your_password';
 ```
 
 5. Change Ownership of the Database: Alter the ownership of the `eps` database to the new user `eps`.
 
 ```sql
-ALTER DATABASE eps OWNER TO eps;
+ALTER
+DATABASE eps OWNER TO eps;
 ```
 
 6. Grant Necessary Privileges to the User: Grant the necessary permissions for the eps user to manage objects within the
@@ -481,23 +487,30 @@ Please copy these one-by-one to the shell; they do not copy well en masse.
 
 ```sql
 -- Connect to the database named 'eps'
-\c eps;
+\c
+eps;
 
 -- Grant usage on the schema 'public' to 'eps'
-GRANT USAGE ON SCHEMA public TO eps;
+GRANT USAGE ON SCHEMA
+public TO eps;
 
 -- Grant create privileges on the schema 'public' to 'eps'
-GRANT CREATE ON SCHEMA public TO eps;
+GRANT CREATE
+ON SCHEMA public TO eps;
 
 -- Grant all privileges on all tables in the schema 'public' to 'eps'
-GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO eps;
+GRANT ALL PRIVILEGES ON ALL
+TABLES IN SCHEMA public TO eps;
 
 -- Grant all privileges on all sequences in the schema 'public' to 'eps'
-GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO eps;
+GRANT ALL PRIVILEGES ON ALL
+SEQUENCES IN SCHEMA public TO eps;
 
 -- Grant privileges to create and manage tables within the 'public' schema
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO eps;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO eps;
+ALTER
+DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO eps;
+ALTER
+DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO eps;
 ```
 
 ### Python Setup
@@ -509,9 +522,11 @@ These setup instructions assume the use of [uv](https://docs.astral.sh/uv/)
 ```bash
 uv sync
 ```
+
 2. Define local environment database configuration (optional)
 
-The default database configuration for the Edge Parameter Store application can be found in [settings.py](./parameter_store/settings.py).
+The default database configuration for the Parameter Store application can be found
+in [settings.py](./parameter_store/settings.py).
 To override these settings for your local environment, define relevant environment variables as needed.
 
 ```bash

--- a/docs/iap-programmatic-access.md
+++ b/docs/iap-programmatic-access.md
@@ -1,6 +1,6 @@
-# Programmatic Access to Edge Parameter Store (EPS) with Google Service Accounts
+# Programmatic Access to Parameter Store (EPS) with Google Service Accounts
 
-This document outlines how to programmatically access an EPS (Edge Parameter Store) instance hosted on Google Cloud Platform (GCP) and protected by Identity-Aware Proxy (IAP). Access is achieved using a Google Service Account (GSA).
+This document outlines how to programmatically access an EPS (Parameter Store) instance hosted on Google Cloud Platform (GCP) and protected by Identity-Aware Proxy (IAP). Access is achieved using a Google Service Account (GSA).
 
 ## Overview
 

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -1,6 +1,6 @@
-# **Edge Parameter Store \- Infrastructure Overview**
+# **Parameter Store \- Infrastructure Overview**
 
-This document outlines the GCP architecture for the Edge Parameter Store (EPS) application. The design is implemented in
+This document outlines the GCP architecture for the Parameter Store (EPS) application. The design is implemented in
 Terraform and assumes a target audience familiar with GCP resources and Terraform syntax.
 
 The core of the application is a Django project deployed as a `google_cloud_run_v2_service`. Traffic is routed through

--- a/examples/eps_to_csv/workflows/README.md
+++ b/examples/eps_to_csv/workflows/README.md
@@ -7,7 +7,7 @@ This document describes the GitHub Actions workflows defined in the `examples/ep
 The behavior of the several caller workflows defined below depend on the value of the `MODE` repository variable. This variable dictates the primary source of truth for configuration:
 
 *   **`GIT` Mode:** In this mode, the configuration source of truth is considered to be the files directly within the Git repository (e.g., the `cluster-intent-source-of-truth.csv` file). Changes are typically managed through standard Git pull requests, and hydration processes might be triggered directly based on file modifications within the repository. There will be no interaction with the EPS.
-*   **`EPS` Mode:** In this mode, the primary source of truth is the external Edge Parameter Store (EPS). Workflows are designed to interact with EPS to:
+*   **`EPS` Mode:** In this mode, the primary source of truth is the external Parameter Store (EPS). Workflows are designed to interact with EPS to:
     *   Check for configuration drift between the Git repository files and EPS.
     *   Fetch the latest configuration from EPS to update files in the Git repository (e.g., generating the SOT CSV).
     *   Reconcile differences found during drift checks.
@@ -20,14 +20,14 @@ The specific `MODE` set for the repository in the GitHub Actions variables deter
 All the four workflows documented below call the reusable workflow [csv_updater_pipeline.yaml](./csv_updater_reusable_pipeline.yaml) with different parameters to invoke different jobs enabled by the reusable workflow. For more information on the configuration options of that workflow, please refer to [REUSABLE_WORKFLOW.md](./reusable_workflow.md)
 
 *   **`manual_update_sot.yaml`**: A workflow dispatch that allows manual trigger of the Source of Truth (SOT) CSV generation process, typically used for cluster additions or updates. To hydrate new clusters that are added to EPS.
-*   **`call_hydration_pipeline_full.yaml`**: Automatically checks for configuration drift against the Edge Parameter Store (EPS) when pull requests modify specific directories, and potentially triggers a hydration process if no drift is detected (when in EPS mode).
+*   **`call_hydration_pipeline_full.yaml`**: Automatically checks for configuration drift against the Parameter Store (EPS) when pull requests modify specific directories, and potentially triggers a hydration process if no drift is detected (when in EPS mode).
 *   **`eps_commands_pipeline.yaml`**: Enables triggering EPS drift checks (`/fetch-eps`) or reconciliation (`/sync-eps`) via comments on open pull requests when the repository is in `EPS` mode.
 
 ---
 
 ### 1. `manual_update_sot.yaml` - Generate SOT CSV (Manual Trigger)
 
-This workflow provides a way to manually generate or update a Source of Truth (SOT) CSV file based on data from the Edge Parameter Store (EPS). This is intended to be used for scenarios where clusters are added/modified in the EPS and need to be hydrated in the repositories.
+This workflow provides a way to manually generate or update a Source of Truth (SOT) CSV file based on data from the Parameter Store (EPS). This is intended to be used for scenarios where clusters are added/modified in the EPS and need to be hydrated in the repositories.
 
 **Trigger:**
 
@@ -51,7 +51,7 @@ This workflow relies on the following repository variables being correctly confi
 *   `GOOGLE_CLOUD_PROJECT`: GCP Project ID.
 *   `WIF_PROVIDER`: Workload Identity Federation Provider URL.
 *   `SERVICE_ACCOUNT`: GCP Service Account email with workload Identity Federation to GitHub Repo.
-*   `EPS_HOST`: Hostname/URL of the Edge Parameter Store.
+*   `EPS_HOST`: Hostname/URL of the Parameter Store.
 *   `EPS_CLIENT_ID`: Oauth IAP Client ID for authenticating with EPS.
 
 ---
@@ -61,7 +61,7 @@ This workflow relies on the following repository variables being correctly confi
 This workflow automatically runs on pull requests that modify files within the `hydrated/` or `templates/` directories.
 
 In `EPS` mode :
-* It checks for configuration drift against the Edge Parameter Store (EPS).
+* It checks for configuration drift against the Parameter Store (EPS).
 * If no drift is detected, it proceeds ** trigger the actual hydration process.
 
 If `GIT` mode :
@@ -87,14 +87,14 @@ This workflow relies on the following repository variables being correctly confi
 *   `GOOGLE_CLOUD_PROJECT`: GCP Project ID (for `EPS` mode).
 *   `WIF_PROVIDER`: Workload Identity Federation Provider URL (for `EPS` mode).
 *   `SERVICE_ACCOUNT`: GCP Service Account email (for `EPS` mode).
-*   `EPS_HOST`: Hostname/URL of the Edge Parameter Store (for `EPS` mode).
+*   `EPS_HOST`: Hostname/URL of the Parameter Store (for `EPS` mode).
 *   `EPS_CLIENT_ID`: Oauth IAP Client ID for authenticating with EPS (for `EPS` mode).
 
 ---
 
 ### 3. `eps_commands_pipeline.yaml` - EPS Commands via PR Comments
 
-This workflow allows triggering actions related to the Edge Parameter Store (EPS) by posting specific commands as comments on open pull requests. It only runs when the repository variable `MODE` is set to `EPS`. The commands are disabled in `GIT` mode.
+This workflow allows triggering actions related to the Parameter Store (EPS) by posting specific commands as comments on open pull requests. It only runs when the repository variable `MODE` is set to `EPS`. The commands are disabled in `GIT` mode.
 
 **Trigger:**
 
@@ -120,7 +120,7 @@ This workflow relies on the following repository variables being correctly confi
 *   `GOOGLE_CLOUD_PROJECT`: GCP Project ID.
 *   `WIF_PROVIDER`: Workload Identity Federation Provider URL.
 *   `SERVICE_ACCOUNT`: GCP Service Account email.
-*   `EPS_HOST`: Hostname/URL of the Edge Parameter Store.
+*   `EPS_HOST`: Hostname/URL of the Parameter Store.
 *   `EPS_CLIENT_ID`: Oauth IAP Client ID for authenticating with EPS.
 
 ---

--- a/examples/terraform/README.md
+++ b/examples/terraform/README.md
@@ -12,7 +12,7 @@
 | Cloud Build Connection Admin  | `roles/cloudbuild.connectionAdmin`  | Allows Cloud Build to connect to external source code repositories like GitHub. |
 | Cloud Build Editor            | `roles/cloudbuild.builds.editor`    | Required to create and manage Cloud Build triggers.                         |
 | Cloud Build WorkerPool Owner  | `roles/cloudbuild.workerPoolOwner`  | Creates private worker pools for Cloud Build for data loading.              |
-| Cloud Run Admin               | `roles/run.admin`                   | Required for the EPS (Edge Parameter Store) application.                    |
+| Cloud Run Admin               | `roles/run.admin`                   | Required for the Parameter Store (EPS) application.                    |
 | Cloud SQL Admin               | `roles/cloudsql.admin`              | EPS requires a database, and this setup presumes the use of Cloud SQL.      |
 | Cloud Storage Admin           | `roles/storage.admin`               | Creates a Cloud Storage bucket to hold submitted jobs for Cloud Build.      |
 | Compute Load Balancer Admin   | `roles/compute.loadBalancerAdmin`   | Manages the load balancer components associated with the application.       |

--- a/parameter_store/admin.py
+++ b/parameter_store/admin.py
@@ -44,9 +44,9 @@ from .models import (
 
 
 class ParamStoreAdmin(usites.UnfoldAdminSite):
-    site_header = "Edge Parameter Store"
-    site_title = "Edge Parameter Store"
-    index_title = "Edge Parameter Store"
+    site_header = "Parameter Store"
+    site_title = "Parameter Store"
+    index_title = "Parameter Store"
 
     def get_app_list(self, request, app_label=None):
         """Return a sorted list of all the installed apps that have been registered to this

--- a/parameter_store/settings.py
+++ b/parameter_store/settings.py
@@ -240,7 +240,8 @@ UNFOLD = {
     "USER_LINKS": [
         {"template": "unfold/helpers/userlinks.html"},
     ],
-    "SITE_HEADER": "Edge Parameter Store",
+    "SITE_HEADER": "Parameter Store",
+    "SITE_TITLE": "Parameter Store",
     "COLORS": {
         "base": {
             "50": "249 250 251",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "parameter-store"
 version = "1.2.1"
-description = "Edge Parameter Store is a Django application that holds parameter data for deployments of Google Distributed Cloud Connected clusters"
+description = "Parameter Store is a Django application that holds parameter data for deployments of Google Distributed Cloud Connected clusters"
 authors = [
     { name = "Paul Durivage", email = "durivage@google.com" },
     { name = "Daniel Xia", email = "danielxia@google.com" },


### PR DESCRIPTION
ensures 'Django admin' is not shown; is consistent with docs.  Also updates docs to be universally consistent.  Continues to use EPS acronym because...reasons.  Vars and such, backwards compatibility, posterity. 